### PR TITLE
Initial pip export script & typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Example of how to use cmake and swig together with C++ to build Python bindings.
 changing and none of the examples I found worked out of the box on the Mac, so here's one that
 works on Mac and Ubuntu with the latest verson of swig and cmake (as of today: 16 November 2021).
 
-Ubunto: You might have to update your version of cmake on Ubuntu, apt does not (did not?) support a high enough
+Ubuntu: You might have to update your version of cmake on Ubuntu, apt does not (did not?) support a high enough
 version of cmake for this to work so you might need to remove the apt version and install it with snap:
 
 ```

--- a/makepypi.sh
+++ b/makepypi.sh
@@ -1,0 +1,8 @@
+ #!/bin/bash 
+cd build
+cmake ..
+make
+mv example.py ..
+mv _example.so ..
+touch ../setup.cfg # dummy file for now - but will use it for config os platform
+python3 ../setup.py sdist #

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,9 @@
+from setuptools import setup, Extension
+setup(
+    name='PACKAGENAME',
+    version='PACKAGEVERSION',  # specified elsewhere
+    packages=[''],
+    package_dir={'': '.'}, # the . is important else package_data option gets ignored 
+   package_data={'': ['_example.so']},
+
+)


### PR DESCRIPTION
I've made the initial work for PyPi script that allows this project to be exported as pip package that can be easily published to PyPi for users to install. As this is an initial commit, it works for Linux at this moment. I Will be working on a Mac version of it so it works in one script 

Additionally, I've found typo in the README.md and fixed it accordingly 

**PyPi URL :** https://pypi.org/project/pypithang/ 


**Tested on**
Tested on python 3.6 , python 3.7 , python 3.8 on anaconda version 4.11 - running on CentOS 9 
