### PR TITLE
Updated CMAKE to include Support for Universal Binary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,12 @@ set_property(SOURCE example.i PROPERTY CPLUSPLUS ON)
 swig_add_library(example TYPE MODULE LANGUAGE python SOURCES example.i example.cpp)
 
 #
+#   Tell CMAKE that for OSX we need universal binary and enforce it
+#
+
+set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64" CACHE STRING "Build architectures for Mac OS X" FORCE)
+
+#
 #	Tell CMAKE_SWIG that we have our own include directories
 #
 set_property(GLOBAL PROPERTY SWIG_USE_TARGET_INCLUDE_DIRECTORIES ON)


### PR DESCRIPTION
**Problem Statement:**
Currently CMAKE build script only compiles for x86_64 on Mac (verified using lipo -archs on MacOS 11.5.2). Therefore it does not compile for arm64 architecture 

**Solution:** 
Added the line which makes cmake to generate universal binary for both x86_64 and arm64 based on the instructions from https://cmake.org/cmake/help/latest/variable/CMAKE_OSX_ARCHITECTURES.html . Force flag was added as initially the binaries were only for x86_64 despite using the flag. Force was added to make sure that the binaries produced are meant for x86_64 and arm64 

**Testing Steps**
Verify that that the lipo returns arm64 and x86_64 
`lipo -archs _example.so `
**Expected Output**
`x86_64 arm64`
