### PR TITLE
PIP Scripts to create Binary Packages

### DIFF
--- a/makepypi.sh
+++ b/makepypi.sh
@@ -1,0 +1,18 @@
+#!/bin/bash 
+# run the commands to build the distribution
+mkdir -p output 
+cd build
+cmake ..
+make
+mv example.py ../output
+mv _example.so ../output
+touch ../setup.cfg
+cd ..
+python3 setup.py bdist_wheel
+# This hack is needed to make it to work for linux distro -> https://www.python.org/dev/peps/pep-0513/#rationale
+# Refer to https://github.com/pypa/manylinux - we target 2_17 (Uubntu 20.04, Fedora 32+ , CentOS 8 etc......)
+if [ "$(expr substr $(uname -s) 1 5)" == "Linux" ] 
+then
+cd dist
+rename cp36-cp36m-linux_x86_64.whl cp36-cp36m-manylinux_2_17_x86_64.whl *.whl  # TODO: handle in dynamic way with cp thingy
+fi

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,24 @@
+from setuptools import setup, Extension
+
+class BinaryDistribution(Distribution):
+    def has_ext_modules(foo):
+        return True
+
+setup(
+    name='PACKAGENAME',
+    version='PACKAGEVERSION',  # specified elsewhere
+    author='',
+    author_email='',
+    download_url='',
+    packages=['output'],
+   # package_dir={'': '.'},
+   package_data={'': ['_example.so']}, #replace me with your package data
+   classifiers=[
+       'Programming Language :: Python :: 3',
+       'Operating System :: MacOS :: MacOS X',
+       'Operating System :: POSIX :: Linux', # WSL will be treated as Linux so it's not a problem
+   ],
+   python_requires='>=3.6'
+   distclass=BinaryDistribution
+
+)


### PR DESCRIPTION
Hi,

In this commit, you'll find two files

- setup.py - This is the basic script to tell setuptools to create a binary wheel for the platform where this script is being run
- makepypi.sh - This script basically compiles the binary (wheel). If it is on linux, it makes sure that the package name meets the needs of PEP 0513

Limitations
1. The script is currently hardcoded to 2_17 manylinux - maybe in the future - I'll include the right version number
2. It makes an assumption that we need python3.6 (following this example) 
